### PR TITLE
feat: add Schema.org JSON-LD structured data to all pages

### DIFF
--- a/aviso-legal.html
+++ b/aviso-legal.html
@@ -15,6 +15,46 @@
 
     <link rel="canonical" href="https://marsodistribuciones.com/aviso-legal.html">
 
+    <!-- Structured Data: BreadcrumbList + WebPage -->
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@graph": [
+        {
+          "@type": "BreadcrumbList",
+          "itemListElement": [
+            {
+              "@type": "ListItem",
+              "position": 1,
+              "name": "Inicio",
+              "item": "https://marsodistribuciones.com/"
+            },
+            {
+              "@type": "ListItem",
+              "position": 2,
+              "name": "Aviso Legal",
+              "item": "https://marsodistribuciones.com/aviso-legal.html"
+            }
+          ]
+        },
+        {
+          "@type": "WebPage",
+          "@id": "https://marsodistribuciones.com/aviso-legal.html",
+          "url": "https://marsodistribuciones.com/aviso-legal.html",
+          "name": "Aviso Legal | Marso Distribuciones",
+          "description": "Aviso Legal de Marso Distribuciones - Información legal y condiciones de uso de nuestro sitio web.",
+          "inLanguage": "es-ES",
+          "isPartOf": {
+            "@id": "https://marsodistribuciones.com/#website"
+          },
+          "publisher": {
+            "@id": "https://marsodistribuciones.com/#organization"
+          }
+        }
+      ]
+    }
+    </script>
+
     <title>Aviso Legal | Marso Distribuciones</title>
     
     <!-- Favicon -->

--- a/condiciones-venta.html
+++ b/condiciones-venta.html
@@ -15,6 +15,46 @@
 
     <link rel="canonical" href="https://marsodistribuciones.com/condiciones-venta.html">
 
+    <!-- Structured Data: BreadcrumbList + WebPage -->
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@graph": [
+        {
+          "@type": "BreadcrumbList",
+          "itemListElement": [
+            {
+              "@type": "ListItem",
+              "position": 1,
+              "name": "Inicio",
+              "item": "https://marsodistribuciones.com/"
+            },
+            {
+              "@type": "ListItem",
+              "position": 2,
+              "name": "Condiciones de Venta",
+              "item": "https://marsodistribuciones.com/condiciones-venta.html"
+            }
+          ]
+        },
+        {
+          "@type": "WebPage",
+          "@id": "https://marsodistribuciones.com/condiciones-venta.html",
+          "url": "https://marsodistribuciones.com/condiciones-venta.html",
+          "name": "Condiciones de Venta | Marso Distribuciones",
+          "description": "Condiciones de Venta de Marso Distribuciones - Información contractual sobre pedidos, precios y entregas.",
+          "inLanguage": "es-ES",
+          "isPartOf": {
+            "@id": "https://marsodistribuciones.com/#website"
+          },
+          "publisher": {
+            "@id": "https://marsodistribuciones.com/#organization"
+          }
+        }
+      ]
+    }
+    </script>
+
     <title>Condiciones de Venta | Marso Distribuciones</title>
     
     <!-- Favicon -->

--- a/index.html
+++ b/index.html
@@ -48,6 +48,102 @@
     <link rel="stylesheet" href="styles.css">
     <link rel="stylesheet" href="dist/output.css">
 
+    <!-- Structured Data: Organization + LocalBusiness + WebSite -->
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@graph": [
+        {
+          "@type": ["Organization", "LocalBusiness", "WholesaleStore"],
+          "@id": "https://marsodistribuciones.com/#organization",
+          "name": "Marso Distribuciones",
+          "url": "https://marsodistribuciones.com/",
+          "logo": {
+            "@type": "ImageObject",
+            "url": "https://marsodistribuciones.com/images/logo_redesSociales_og.webp",
+            "width": 1200,
+            "height": 630
+          },
+          "image": "https://marsodistribuciones.com/images/logo_redesSociales_og.webp",
+          "description": "Mayorista de bebidas en el Valle de Los Pedroches desde 1993. Distribuimos cervezas, vinos, licores, refrescos y aguas minerales a bares, restaurantes y comercios.",
+          "foundingDate": "1993",
+          "address": {
+            "@type": "PostalAddress",
+            "streetAddress": "Polígono Industrial A-422",
+            "addressLocality": "Hinojosa del Duque",
+            "postalCode": "14270",
+            "addressRegion": "Córdoba",
+            "addressCountry": "ES"
+          },
+          "telephone": "+34635190975",
+          "email": "pedidos@marsodistribuciones.com",
+          "openingHoursSpecification": [
+            {
+              "@type": "OpeningHoursSpecification",
+              "dayOfWeek": ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday"],
+              "opens": "08:00",
+              "closes": "18:00"
+            },
+            {
+              "@type": "OpeningHoursSpecification",
+              "dayOfWeek": "Saturday",
+              "opens": "09:00",
+              "closes": "14:00"
+            }
+          ],
+          "contactPoint": {
+            "@type": "ContactPoint",
+            "telephone": "+34635190975",
+            "email": "pedidos@marsodistribuciones.com",
+            "contactType": "customer service",
+            "availableLanguage": "Spanish"
+          },
+          "areaServed": {
+            "@type": "AdministrativeArea",
+            "name": "Valle de Los Pedroches, Córdoba"
+          },
+          "hasOfferCatalog": {
+            "@type": "OfferCatalog",
+            "name": "Catálogo de Bebidas al por Mayor",
+            "itemListElement": [
+              {
+                "@type": "OfferCatalog",
+                "name": "Cervezas",
+                "description": "Cervezas nacionales e importadas en lata, botella y barril"
+              },
+              {
+                "@type": "OfferCatalog",
+                "name": "Vinos y Licores",
+                "description": "Vinos D.O. Montilla-Moriles, cavas y licores premium"
+              },
+              {
+                "@type": "OfferCatalog",
+                "name": "Refrescos",
+                "description": "Coca-Cola, Pepsi, Fanta, Kas y bebidas energéticas"
+              },
+              {
+                "@type": "OfferCatalog",
+                "name": "Aguas Minerales",
+                "description": "Aguas naturales y con gas, formatos de 33cl a 5L"
+              }
+            ]
+          }
+        },
+        {
+          "@type": "WebSite",
+          "@id": "https://marsodistribuciones.com/#website",
+          "url": "https://marsodistribuciones.com/",
+          "name": "Marso Distribuciones",
+          "description": "Mayorista de bebidas al por mayor en el Valle de Los Pedroches",
+          "publisher": {
+            "@id": "https://marsodistribuciones.com/#organization"
+          },
+          "inLanguage": "es-ES"
+        }
+      ]
+    }
+    </script>
+
     <!-- Google Analytics & AdSense -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-ZE1XWD3J2C"></script>
     <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-6608388491200814" crossorigin="anonymous"></script>

--- a/politica-cookies.html
+++ b/politica-cookies.html
@@ -15,6 +15,46 @@
 
     <link rel="canonical" href="https://marsodistribuciones.com/politica-cookies.html">
 
+    <!-- Structured Data: BreadcrumbList + WebPage -->
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@graph": [
+        {
+          "@type": "BreadcrumbList",
+          "itemListElement": [
+            {
+              "@type": "ListItem",
+              "position": 1,
+              "name": "Inicio",
+              "item": "https://marsodistribuciones.com/"
+            },
+            {
+              "@type": "ListItem",
+              "position": 2,
+              "name": "Política de Cookies",
+              "item": "https://marsodistribuciones.com/politica-cookies.html"
+            }
+          ]
+        },
+        {
+          "@type": "WebPage",
+          "@id": "https://marsodistribuciones.com/politica-cookies.html",
+          "url": "https://marsodistribuciones.com/politica-cookies.html",
+          "name": "Política de Cookies | Marso Distribuciones",
+          "description": "Política de Cookies de Marso Distribuciones - Información sobre el uso de cookies.",
+          "inLanguage": "es-ES",
+          "isPartOf": {
+            "@id": "https://marsodistribuciones.com/#website"
+          },
+          "publisher": {
+            "@id": "https://marsodistribuciones.com/#organization"
+          }
+        }
+      ]
+    }
+    </script>
+
     <title>Politica de Cookies | Marso Distribuciones</title>
     
     <!-- Favicon -->

--- a/politica-privacidad.html
+++ b/politica-privacidad.html
@@ -15,6 +15,46 @@
 
     <link rel="canonical" href="https://marsodistribuciones.com/politica-privacidad.html">
 
+    <!-- Structured Data: BreadcrumbList + WebPage -->
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@graph": [
+        {
+          "@type": "BreadcrumbList",
+          "itemListElement": [
+            {
+              "@type": "ListItem",
+              "position": 1,
+              "name": "Inicio",
+              "item": "https://marsodistribuciones.com/"
+            },
+            {
+              "@type": "ListItem",
+              "position": 2,
+              "name": "Política de Privacidad",
+              "item": "https://marsodistribuciones.com/politica-privacidad.html"
+            }
+          ]
+        },
+        {
+          "@type": "WebPage",
+          "@id": "https://marsodistribuciones.com/politica-privacidad.html",
+          "url": "https://marsodistribuciones.com/politica-privacidad.html",
+          "name": "Política de Privacidad | Marso Distribuciones",
+          "description": "Política de Privacidad de Marso Distribuciones - Información sobre el tratamiento de datos personales.",
+          "inLanguage": "es-ES",
+          "isPartOf": {
+            "@id": "https://marsodistribuciones.com/#website"
+          },
+          "publisher": {
+            "@id": "https://marsodistribuciones.com/#organization"
+          }
+        }
+      ]
+    }
+    </script>
+
     <title>Politica de Privacidad | Marso Distribuciones</title>
     
     <!-- Favicon -->


### PR DESCRIPTION
## Summary

- Adds `Organization` + `LocalBusiness` + `WholesaleStore` + `WebSite` schemas to `index.html` via a single `@graph`, covering business name, address, phone, email, founding date, opening hours, service area, and the four product catalog categories
- Adds `BreadcrumbList` + `WebPage` schemas to all four legal pages (`aviso-legal.html`, `politica-privacidad.html`, `politica-cookies.html`, `condiciones-venta.html`), enabling breadcrumb trails in Google search results
- All schemas cross-reference the `#organization` and `#website` entities via `@id`, creating a coherent knowledge graph for Google

## Test plan

- [ ] Validate `index.html` at [Google Rich Results Test](https://search.google.com/test/rich-results)
- [ ] Validate legal pages at [Schema.org Validator](https://validator.schema.org/)
- [ ] Confirm no console errors on the live site after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)